### PR TITLE
Fix border with relative line height

### DIFF
--- a/src/modules/_fonts.scss
+++ b/src/modules/_fonts.scss
@@ -37,12 +37,10 @@ $font-stacks: (
 
 @mixin baseline-align {
   vertical-align: baseline;
-  @if(variable-exists(line-heights)) {
-    $bottom: calc((#{if(unitless(nth($line-heights, 1)), 1em, 1)} * var(--line-height) - 1em * var(--baseline-shift-factor)) / 2);
-    @supports(bottom: $bottom) {
-      vertical-align: var(--baseline-vertical-align, baseline);
-      position: var(--baseline-position, static);
-      bottom: $bottom;
-    }
+  $bottom: calc((var(--line-height) - 1em * var(--baseline-shift-factor)) / 2);
+  @supports(bottom: $bottom) {
+    vertical-align: var(--baseline-vertical-align, baseline);
+    position: var(--baseline-position, static);
+    bottom: $bottom;
   }
 }

--- a/src/modules/_sizing.scss
+++ b/src/modules/_sizing.scss
@@ -26,8 +26,7 @@ $readable-line-length-max: 75ch !default;
   font-size: $font-size;
   @if (type-of($line-height) == 'number' and $line-height != 0) {
     @if (unit($line-height) == unit($spacing-base)) {
-      $factor: round($line-height/$spacing-base);
-      --line-height: calc(#{$factor} * #{spacing-base-var()});
+      --line-height: calc(#{$line-height/$spacing-base} * #{spacing-base-var()});
     } @else if (unitless($line-height)) {
       --line-height: #{$line-height}em;
     } @else {

--- a/src/modules/_sizing.scss
+++ b/src/modules/_sizing.scss
@@ -28,6 +28,8 @@ $readable-line-length-max: 75ch !default;
     @if (unit($line-height) == unit($spacing-base)) {
       $factor: round($line-height/$spacing-base);
       --line-height: calc(#{$factor} * #{spacing-base-var()});
+    } @else if (unitless($line-height)) {
+      --line-height: #{$line-height}em;
     } @else {
       --line-height: #{$line-height};
     }


### PR DESCRIPTION
This PR makes --line-height always have a unit so that calculations can rely on it being a proper length.