### PR TITLE
Fix inline-blocks in inline context

### DIFF
--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -1,13 +1,17 @@
 @mixin display-block($line-height: inherit) {
   display: block;
-  @if ($line-height) {
+  @if ($line-height == inherit) {
+    line-height: var(--line-height, inherit);
+  } @else if($line-height) {
     line-height: $line-height;
   }
 }
 
 @mixin display-inline-block($vertical-align: bottom, $line-height: inherit) {
   display: inline-block;
-  @if ($line-height) {
+  @if ($line-height == inherit) {
+    line-height: var(--line-height, inherit);
+  } @else if($line-height) {
     line-height: $line-height;
   }
   @if ($vertical-align) {

--- a/src/placeholders/_text.scss
+++ b/src/placeholders/_text.scss
@@ -42,7 +42,7 @@ $font-size-smaller: smaller !default;
 /* %text-small-block */
 %text-small-block {
   @include size-text(font-size-em($font-size-smaller), inherit);
-  display: block;
+  @include display-block();
 }
 
 /* %text-x-small */
@@ -56,7 +56,7 @@ $font-size-smaller: smaller !default;
 %text-x-small-block {
   $font-size-smaller: font-size-em($font-size-smaller);
   @include size-text($font-size-smaller*strip-unit($font-size-smaller), inherit);
-  display: block;
+  @include display-block();
 }
 
 /* %text-inherit */


### PR DESCRIPTION
Use --line-height by default when setting elements to block.

This solves problems where inline-blocks are within other text (usually inline) that had their line-height set to 0.