### PR TITLE
Inherit line height

### DIFF
--- a/src/modules/_sizing.scss
+++ b/src/modules/_sizing.scss
@@ -34,7 +34,11 @@ $readable-line-length-max: 75ch !default;
     }
     line-height: var(--line-height, #{$line-height});
   } @else {
-    line-height: $line-height;
+    @if ($line-height == inherit) {
+      line-height: var(--line-height, inherit);
+    } @else if($line-height) {
+      line-height: $line-height;
+    }
   }
 }
 

--- a/src/placeholders/_text.scss
+++ b/src/placeholders/_text.scss
@@ -1,6 +1,5 @@
 $font-sizes: medium large x-large xx-large !default;
 $line-heights: 1.5 1.4 1.3 1.2 !default;
-$line-heights-tight: 1 1 1 1 !default;
 $font-size-smaller: smaller !default;
 
 /* Placeholders for text */
@@ -35,20 +34,20 @@ $font-size-smaller: smaller !default;
 
 /* %text-small */
 %text-small {
-  @include size-text(font-size-em($font-size-smaller), 0);
+  @include size-text(font-size-em($font-size-smaller), false);
   @extend %text-inline;
 }
 
 /* %text-small-block */
 %text-small-block {
   @include size-text(font-size-em($font-size-smaller), inherit);
-  @include display-block();
+  display: block;
 }
 
 /* %text-x-small */
 %text-x-small {
   $font-size-smaller: font-size-em($font-size-smaller);
-  @include size-text($font-size-smaller*strip-unit($font-size-smaller), 0);
+  @include size-text($font-size-smaller*strip-unit($font-size-smaller), false);
   @extend %text-inline;
 }
 
@@ -56,7 +55,7 @@ $font-size-smaller: smaller !default;
 %text-x-small-block {
   $font-size-smaller: font-size-em($font-size-smaller);
   @include size-text($font-size-smaller*strip-unit($font-size-smaller), inherit);
-  @include display-block();
+  display: block;
 }
 
 /* %text-inherit */

--- a/src/utilities/text/_sizing.scss
+++ b/src/utilities/text/_sizing.scss
@@ -35,6 +35,10 @@
   @extend %text-1;
 }
 
+.text-body-block {
+  @extend %text-1-block;
+}
+
 .text-inherit {
   @extend %text-inherit;
 }


### PR DESCRIPTION
This PR makes text-size settings use `--line-height` if it's available when inheriting line height.