### PR TITLE
Fix clearfix supports

### DIFF
--- a/src/modules/_clearfix.scss
+++ b/src/modules/_clearfix.scss
@@ -1,6 +1,6 @@
 // Clearfix from https://css-tricks.com/snippets/css/clear-fix/
 
-// Add a supports-condition to disable the clearfix when the condition is supported
+// Provide the $supports-condition to disable the clearfix when that condition is supported
 @mixin clearfix($supports-condition: false) {
   &::after {
     content: "";
@@ -9,7 +9,7 @@
   }
 
   @if ($supports-condition) {
-    @supports (#{$supports-condition}) {
+    @supports (#{ '(' + $supports-condition + ')' }) {
       &::after {
         display: none;
       }

--- a/src/modules/_clearfix.scss
+++ b/src/modules/_clearfix.scss
@@ -9,7 +9,7 @@
   }
 
   @if ($supports-condition) {
-    @supports (#{ '(' + $supports-condition + ')' }) {
+    @supports (#{"(" + $supports-condition + ")"}) {
       &::after {
         display: none;
       }

--- a/src/modules/_clearfix.scss
+++ b/src/modules/_clearfix.scss
@@ -8,8 +8,8 @@
     clear: both;
   }
 
-  @if($supports-condition) {
-    @supports(#{$supports-condition}) {
+  @if ($supports-condition) {
+    @supports (#{$supports-condition}) {
       &::after {
         display: none;
       }


### PR DESCRIPTION
This PR fixes a problem where parenthesis around the @supports condition were removed in the final CSS.

I don't know why, but adding quoted parentheses around the condition string seems to solve it.