### PR TITLE
Avoid middle lightness

### DIFF
--- a/src/modules/_colors-register-defaults.scss
+++ b/src/modules/_colors-register-defaults.scss
@@ -1,7 +1,7 @@
 @import "colors";
 
 // Generate a random primary color and corresponding text color if not already defined in $colors map
-@include register-color(primary, hsl(random(361), 50 + (2*round(random()) - 1) * (10 + random(11)), 20+random(60)));
+@include register-color(primary, hsl(random(361), 50 + (2*round(random()) - 1) * (4 + random(16)), 20+random(60)));
 
 // Generate body background and text color if not already defined in $colors map
 @if lightness(get-color(primary)) < 50% {

--- a/src/modules/_colors-register-defaults.scss
+++ b/src/modules/_colors-register-defaults.scss
@@ -1,7 +1,7 @@
 @import "colors";
 
 // Generate a random primary color and corresponding text color if not already defined in $colors map
-@include register-color(primary, hsl(random(361), 30+random(60), 20+random(60)));
+@include register-color(primary, hsl(random(361), 50 + (2*round(random()) - 1) * (10 + random(11)), 20+random(60)));
 
 // Generate body background and text color if not already defined in $colors map
 @if lightness(get-color(primary)) < 50% {


### PR DESCRIPTION
This PR makes auto generated primary color lightness fall between 30–45% or 55-70%.

Avoiding a lightness close to 50% reduces the risk of generating low contrast backgrounds.

I so wish sass would have built in functions for perceived lightness... or at least som math like `pow`...