### PR TITLE
Indicate invalid form by transparent submit button

### DIFF
--- a/src/extensions/_forms.scss
+++ b/src/extensions/_forms.scss
@@ -86,6 +86,12 @@ span, small {
   }
 }
 
+// Input descriptions
+[id*='description'],
+[id*='Description'] {
+  @extend %description;
+}
+
 /* Inputs */
 
 select {
@@ -370,12 +376,6 @@ label:not([for]) {
       @include display-inline();
     }
   }
-}
-
-// Input descriptions
-[id*='description'],
-[id*='Description'] {
-  @extend %description;
 }
 
 /* .form-inline make a form's contents go inline */

--- a/src/extensions/_forms.scss
+++ b/src/extensions/_forms.scss
@@ -345,6 +345,11 @@ button,
   }
 }
 
+// Submit buttons in invalid forms
+:invalid [type="submit"]:not([formnovalidate]) {
+  opacity: .5;
+}
+
 /* Form layout */
 
 label {


### PR DESCRIPTION
This PR adds transparent styling to submit buttons within invalid forms, in the form extension.