### PR TITLE
Remove unnecessary utility classes

### DIFF
--- a/src/utilities/layout/_display.scss
+++ b/src/utilities/layout/_display.scss
@@ -26,10 +26,5 @@
   display: table-cell;
 }
 
-//TODO: remove the .hidden util? One should use the hidden html attribute anyway
-.hidden {
-  display: none;
-}
-
 @include extend-for-children(block inline-block table-row table-cell);
 @include extend-for-descendants(inline inline-block);

--- a/src/utilities/text/_sizing.scss
+++ b/src/utilities/text/_sizing.scss
@@ -31,15 +31,6 @@
   @extend %text-x-small-block;
 }
 
-// TODO: remove text-body utilities? One should use .text-1 if needed anyway.
-.text-body {
-  @extend %text-1;
-}
-
-.text-body-block {
-  @extend %text-1-block;
-}
-
 .text-inherit {
   @extend %text-inherit;
 }


### PR DESCRIPTION
This PR removes utility classes `hidden`, `text-body` and `text-body-block` as other methods should be used for their effect anyways.