### PR TITLE
Fix layout of flex & grid children

### DIFF
--- a/src/modules/_borders.scss
+++ b/src/modules/_borders.scss
@@ -1,9 +1,9 @@
 $border-width: 1px !default;
 $border-style: solid !default;
 
-@import "../modules/strip-unit";
-@import "../modules/element-types";
-@import "../modules/colors";
+@import "strip-unit";
+@import "element-types";
+@import "colors";
 
 @mixin border-for-fixed-height($sides: top bottom left right, $width: $border-width) {
   @each $side in $sides {

--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -1,19 +1,13 @@
+@import "sizing";
+
 @mixin display-block($line-height: inherit) {
   display: block;
-  @if ($line-height == inherit) {
-    line-height: var(--line-height, inherit);
-  } @else if($line-height) {
-    line-height: $line-height;
-  }
+  @include line-height($line-height);
 }
 
 @mixin display-inline-block($vertical-align: bottom, $line-height: inherit) {
   display: inline-block;
-  @if ($line-height == inherit) {
-    line-height: var(--line-height, inherit);
-  } @else if($line-height) {
-    line-height: $line-height;
-  }
+  @include line-height($line-height);
   @if ($vertical-align) {
     vertical-align: $vertical-align;
   }
@@ -22,9 +16,7 @@
 @mixin display-inline($vertical-align: baseline, $line-height: 0) {
   display: inline;
   // $line-height: 0 will prevent inline elements from affecting the line height of their parents should they have their size or font changed
-  @if ($line-height) {
-    line-height: $line-height;
-  }
+  @include line-height($line-height);
   @if ($vertical-align) {
     vertical-align: $vertical-align;
   }

--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -30,3 +30,16 @@
     @include line-height($line-height);
   }
 }
+
+@mixin display-inline-flex($vertical-align: bottom, $line-height: inherit) {
+  display: inline-flex;
+  @include line-height($line-height);
+  @if ($vertical-align) {
+    vertical-align: $vertical-align;
+  }
+
+  > * {
+    @include line-height($line-height);
+  }
+}
+

--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -21,3 +21,12 @@
     vertical-align: $vertical-align;
   }
 }
+
+@mixin display-flex($line-height: inherit) {
+  display: flex;
+  @include line-height($line-height);
+
+  > * {
+    @include line-height($line-height);
+  }
+}

--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -25,11 +25,7 @@
 @mixin display-flex($line-height: inherit) {
   display: flex;
   @include line-height($line-height);
-
-  > * {
-    @include line-height($line-height);
-    @extend %mt-0 !optional;
-  }
+  @include reset-child-item-layout();
 }
 
 @mixin display-inline-flex($vertical-align: bottom, $line-height: inherit) {
@@ -38,9 +34,27 @@
   @if ($vertical-align) {
     vertical-align: $vertical-align;
   }
+  @include reset-child-item-layout();
+}
 
+@mixin display-grid($line-height: inherit) {
+  display: grid;
+  @include line-height($line-height);
+  @include reset-child-item-layout();
+}
+
+@mixin display-inline-grid($vertical-align: bottom, $line-height: inherit) {
+  display: inline-grid;
+  @include line-height($line-height);
+  @if ($vertical-align) {
+    vertical-align: $vertical-align;
+  }
+  @include reset-child-item-layout();
+}
+
+@mixin reset-child-item-layout() {
   > * {
-    @include line-height($line-height);
+    @include line-height(inherit);
     @extend %mt-0 !optional;
   }
 }

--- a/src/modules/_layout.scss
+++ b/src/modules/_layout.scss
@@ -28,6 +28,7 @@
 
   > * {
     @include line-height($line-height);
+    @extend %mt-0 !optional;
   }
 }
 
@@ -40,6 +41,6 @@
 
   > * {
     @include line-height($line-height);
+    @extend %mt-0 !optional;
   }
 }
-

--- a/src/modules/_sizing.scss
+++ b/src/modules/_sizing.scss
@@ -21,9 +21,14 @@ $readable-line-length-max: 75ch !default;
   }
 }
 
-// Apply font size and line height, and put the line-height in a CSS custom property for use in other calculations
+// Apply font size and line height
 @mixin size-text($font-size, $line-height) {
   font-size: $font-size;
+  @include line-height($line-height);
+}
+
+// Apply line-height and put it in a CSS custom property for use in other calculations
+@mixin line-height($line-height) {
   @if (type-of($line-height) == 'number' and $line-height != 0) {
     @if (unit($line-height) == unit($spacing-base)) {
       --line-height: calc(#{$line-height/$spacing-base} * #{spacing-base-var()});

--- a/src/utilities/layout/_flexbox.scss
+++ b/src/utilities/layout/_flexbox.scss
@@ -8,7 +8,7 @@
 }
 
 .inline-flex {
-  display: inline-flex;
+  @include display-inline-flex();
 }
 
 // Direction

--- a/src/utilities/layout/_flexbox.scss
+++ b/src/utilities/layout/_flexbox.scss
@@ -1,9 +1,10 @@
 // Utilities for flexbox
+@import "../../modules/layout";
 
 // Display
 
 .flex {
-  display: flex;
+  @include display-flex();
 }
 
 .inline-flex {

--- a/src/utilities/layout/_grid.scss
+++ b/src/utilities/layout/_grid.scss
@@ -1,10 +1,15 @@
 // Utilities for grid
 @import "../../modules/sizing";
+@import "../../modules/layout";
 
 // Display
 
 .grid {
-  display: grid;
+  @include display-grid();
+}
+
+.inline-grid {
+  @include display-inline-grid();
 }
 
 .grid-auto-flow-column {


### PR DESCRIPTION
This PR makes grid and flex items inherit line-height and resets their default vertical spacing.

The line-height fixes problems when inline elements are turned into grid or flex items.
The vertical spacing reset is useful when applying flex or grid where all the items now have the same margins.